### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/NameChangeChild/data/questions/name_change_child.yml
+++ b/docassemble/NameChangeChild/data/questions/name_change_child.yml
@@ -397,7 +397,7 @@ continue button field: children[i].six_month_kickout
 question: |
   Sorry
 subquestion: |
-  ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) must have lived in Illinois for at least 6 months to change their name in Illinois.
+  ${children[i].new.name_full()} (${children[i].name_full()}) must have lived in Illinois for at least 6 months to change their name in Illinois.
   
   You can use the [**Legal Services Corporation website**](https://www.lsc.gov/about-lsc/what-legal-aid/get-legal-help) to find a legal aid organization in another state. Or you can use **[Get Legal Help](https://www.illinoislegalaid.org/get-legal-help)** to find free or low-cost legal services in your area.
   
@@ -473,7 +473,7 @@ fields:
 ---
 id: child birth date
 question: |
-  When was ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) born?
+  When was ${children[i].new.name_full()} (${children[i].name_full()}) born?
 subquestion: |
   This program can only change the name of a child under the age of 18. To make name change forms for an adult, use ILAO's [**Name change for an adult Easy Form**](https://www.illinoislegalaid.org/node/36321).
 fields:
@@ -484,9 +484,9 @@ fields:
 ---
 id: child six months
 question: |
-  Has ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) lived in Illinois for at least 6 months?
+  Has ${children[i].new.name_full()} (${children[i].name_full()}) lived in Illinois for at least 6 months?
 subquestion: |
-  If ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) has lived in Illinois without taking a break to live in another state or country, click **Yes**.
+  If ${children[i].new.name_full()} (${children[i].name_full()}) has lived in Illinois without taking a break to live in another state or country, click **Yes**.
 fields:
   - no label: children[i].six_months_in_illinois
     datatype: yesnoradio
@@ -496,19 +496,19 @@ continue button field: children[i].too_old
 question: |
   Sorry
 subquestion: |
-  ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) is an adult. If they want to change their name, they will have to do so their self. To make name change forms for an adult, use ILAO's [**Name change for an adult Easy Form**](https://www.illinoislegalaid.org/node/36321).
+  ${children[i].new.name_full()} (${children[i].name_full()}) is an adult. If they want to change their name, they will have to do so their self. To make name change forms for an adult, use ILAO's [**Name change for an adult Easy Form**](https://www.illinoislegalaid.org/node/36321).
 
   If you have another child whose name you would like to change, click **Next**.
 ---
 id: child user relationship
 question: |
-  What is your relationship to ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})?
+  What is your relationship to ${children[i].new.name_full()} (${children[i].name_full()})?
 field: children[i].user_relationship
 choices:
   - I am their biological parent.: bio
   - I am their adoptive parent.: adopt
   - I am their legal guardian.: custody
-  - ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) has lived in my home for 3 years and is recognized as my adopted child.: years
+  - ${children[i].new.name_full()} (${children[i].name_full()}) has lived in my home for 3 years and is recognized as my adopted child.: years
   - Other: other
 ---
 id: not parent or guardian kickout
@@ -525,13 +525,13 @@ continue button field: children[i].guardian_docs
 question: |
   Guardianship documentation
 subquestion: |
-  You should make a copy of the court order which gave you legal guardianship of ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}).
+  You should make a copy of the court order which gave you legal guardianship of ${children[i].new.name_full()} (${children[i].name_full()}).
 
   Attach a copy of the court order when you file the name change forms with the court.
 ---
 id: child any convictions
 question: |
-  Has ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) been convicted of or placed on probation for any of the following in Illinois or any other state?
+  Has ${children[i].new.name_full()} (${children[i].name_full()}) been convicted of or placed on probation for any of the following in Illinois or any other state?
 fields:
   - no label: children[i].any_convictions
     datatype: checkboxes
@@ -539,13 +539,13 @@ fields:
       - A crime which requires them to register as a sex offender: register
       - Identity theft or aggravated identity theft: identity
       - A felony: felony
-  - Was ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) pardoned of the crime requiring them to register as a sex offender?: children[i].register_pardon 
+  - Was ${children[i].new.name_full()} (${children[i].name_full()}) pardoned of the crime requiring them to register as a sex offender?: children[i].register_pardon 
     show if: children[i].any_convictions['register']
-  - Was ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) pardoned of the identity theft or aggravated identity theft?: children[i].identity_pardon
+  - Was ${children[i].new.name_full()} (${children[i].name_full()}) pardoned of the identity theft or aggravated identity theft?: children[i].identity_pardon
     show if: children[i].any_convictions['identity']
-  - Was ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) pardoned of the felony 10 or more years ago?: children[i].felony_pardon
+  - Was ${children[i].new.name_full()} (${children[i].name_full()}) pardoned of the felony 10 or more years ago?: children[i].felony_pardon
     show if: children[i].any_convictions['felony']
-  - Did ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) complete their probation or sentence for their felony 10 or more years ago?: children[i].felony_complete
+  - Did ${children[i].new.name_full()} (${children[i].name_full()}) complete their probation or sentence for their felony 10 or more years ago?: children[i].felony_complete
 validation code: |
   children[i].in_need_of_pardon = False
   if children[i].any_convictions['register'] == True:
@@ -564,13 +564,13 @@ question: |
   Sorry
 subquestion: |
   % if children[i].register_pardon == False:
-  ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) must have been pardoned for their crime requiring them to register as a sex offender in order to use this program.
+  ${children[i].new.name_full()} (${children[i].name_full()}) must have been pardoned for their crime requiring them to register as a sex offender in order to use this program.
   % endif
   % if children[i].identity_pardon == False:
-  ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) must have been pardoned for their identity theft crime.
+  ${children[i].new.name_full()} (${children[i].name_full()}) must have been pardoned for their identity theft crime.
   % endif
   % if children[i].felony_pardon == False and children[i].felony_complete == False:
-  ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) must have been pardoned or completed their probation or sentence over 10 years ago.
+  ${children[i].new.name_full()} (${children[i].name_full()}) must have been pardoned or completed their probation or sentence over 10 years ago.
   % endif
   
   If you want to change the name of a different child, click **Next**.
@@ -578,9 +578,9 @@ subquestion: |
 id: child name change reason
 question: |
   % if i == 0:
-  Why are you changing the child's name from "${children[i].name.full(middle='full')}" to "${children[i].new.name.full(middle='full')}?"
+  Why are you changing the child's name from "${children[i].name_full()}" to "${children[i].new.name_full()}?"
   % else:
-  Why are you changing the ${ordinal(i)} child's name from "${children[i].name.full(middle='full')}" to "${children[i].new.name.full(middle='full')}?"
+  Why are you changing the ${ordinal(i)} child's name from "${children[i].name_full()}" to "${children[i].new.name_full()}?"
   % endif
 subquestion: |
   Check all that apply.
@@ -600,7 +600,7 @@ fields:
 ---
 id: child new name
 question: |
-  What would you like to change ${children[i].name.full(middle='full')}'s name to?
+  What would you like to change ${children[i].name_full()}'s name to?
 subquestion: |
   **Note:** If their new name uses a suffix that is not listed, you can enter it in the **Last name** field with their last name.
 fields:
@@ -615,9 +615,9 @@ fields:
 ---
 id: child birth address
 question: |
-  ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s birth place
+  ${children[i].new.name_full()} (${children[i].name_full()})'s birth place
 fields:
-  - Was ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) born in the United States?: children[i].birth_place.in_america
+  - Was ${children[i].new.name_full()} (${children[i].name_full()}) born in the United States?: children[i].birth_place.in_america
     datatype: yesnoradio
     default: True
   - City: children[i].birth_place.city
@@ -634,7 +634,7 @@ fields:
 ---
 id: child address
 question: |
-  What is ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s address?
+  What is ${children[i].new.name_full()} (${children[i].name_full()})'s address?
 subquestion: |
   **This address will appear on your court forms.**
   
@@ -652,11 +652,11 @@ fields:
 ---
 id: have other parent
 question: |
-  Does ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) have another parent?
+  Does ${children[i].new.name_full()} (${children[i].name_full()}) have another parent?
 subquestion: |
-  If ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) has another known biological parent or parent listed on the birth certificate other than you, you should click **Yes** unless they have died.
+  If ${children[i].new.name_full()} (${children[i].name_full()}) has another known biological parent or parent listed on the birth certificate other than you, you should click **Yes** unless they have died.
   
-  If ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) only has guardians or custodians, you should click **No**. The program will ask about guardians and custodians later.
+  If ${children[i].new.name_full()} (${children[i].name_full()}) only has guardians or custodians, you should click **No**. The program will ask about guardians and custodians later.
 field: children[i].other_parent_status
 choices:
   - Yes: has_other_parent
@@ -672,13 +672,13 @@ validation code: |
 id: deceased info
 continue button field: children[i].deceased_info
 question: |
-  About ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s deceased parent
+  About ${children[i].new.name_full()} (${children[i].name_full()})'s deceased parent
 subquestion: |
-  You may need to prove to the court that ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s other parent has passed away. Be prepared to present a copy of their death certificate to the judge.
+  You may need to prove to the court that ${children[i].new.name_full()} (${children[i].name_full()})'s other parent has passed away. Be prepared to present a copy of their death certificate to the judge.
 ---
 id: main other parent
 question: |
-  What is the name of ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s other parent?
+  What is the name of ${children[i].new.name_full()} (${children[i].name_full()})'s other parent?
 fields:
   - First: children[i].main_other_parent.name.first
   - Middle: children[i].main_other_parent.name.middle  
@@ -688,7 +688,7 @@ fields:
     code: |
       name_suffix()
     required: False 
-#  - ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) does not have another parent.: children[i].no_main_parent
+#  - ${children[i].new.name_full()} (${children[i].name_full()}) does not have another parent.: children[i].no_main_parent
 #    datatype: yesnowide
 #validation code: |
 #  if ((not showifdef('children[i].main_other_parent.name.first') or not showifdef('children[i].main_other_parent.name.last')) and \
@@ -698,12 +698,12 @@ fields:
 id: any other parents
 question: |
   % if children[i].no_main_parent == False:
-  Does ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) have any parents, guardians, or custodians other than you and ${children[i].main_other_parent}?
+  Does ${children[i].new.name_full()} (${children[i].name_full()}) have any parents, guardians, or custodians other than you and ${children[i].main_other_parent}?
   % else:
-  Does ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) have any guardians or custodians other than you?
+  Does ${children[i].new.name_full()} (${children[i].name_full()}) have any guardians or custodians other than you?
   % endif
 subquestion: |
-  Anyone who has custody over ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) is their custodian.
+  Anyone who has custody over ${children[i].new.name_full()} (${children[i].name_full()}) is their custodian.
 fields:
   - no label: children[i].any_other_parents
     datatype: yesnoradio
@@ -719,7 +719,7 @@ subquestion: |
 ---
 #id: child other parent
 #question: |
-#  Does ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) have a biological or adoptive parent other than you?
+#  Does ${children[i].new.name_full()} (${children[i].name_full()}) have a biological or adoptive parent other than you?
 #fields:
 #  - no label: children[i].include_other_parent
 #    datatype: yesnoradio
@@ -727,9 +727,9 @@ subquestion: |
 #id: child third parent guardian
 #question: |
 #  % if children[i].include_other_parent == True:
-#  Does ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) have a parent or guardian other than you and ${children[i].parents[0].name.full(middle='full')}?
+#  Does ${children[i].new.name_full()} (${children[i].name_full()}) have a parent or guardian other than you and ${children[i].parents[0].name_full()}?
 #  % else:
-#  Does ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) have a guardian other than you? 
+#  Does ${children[i].new.name_full()} (${children[i].name_full()}) have a guardian other than you? 
 #  % endif
 #fields:
 #  - no label: children[i].include_third_parent_guardian
@@ -738,9 +738,9 @@ subquestion: |
 id: child custody haver
 question: |
   % if children[i].include_other_parent == False and children[i].include_third_parent_guardian == False:
-  Does anyone other than you have physical custody over ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})?
+  Does anyone other than you have physical custody over ${children[i].new.name_full()} (${children[i].name_full()})?
   % else:
-  Does anyone else have physical custody over ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})?
+  Does anyone else have physical custody over ${children[i].new.name_full()} (${children[i].name_full()})?
   % endif
 fields:
   - no label: children[i].include_custody_haver
@@ -765,7 +765,7 @@ fields:
 ---
 id: parent type
 question: |
-  Is ${children[i].parents[j].name.full(middle='full')} a parent, guardian, or custodian?
+  Is ${children[i].parents[j].name_full()} a parent, guardian, or custodian?
 field: children[i].parents[j].parent_type
 choices:
   - Parent
@@ -786,7 +786,7 @@ buttons:
 ---
 id: user parental rights terminated
 question: |
-  Were your parental rights over ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) terminated by a court order?
+  Were your parental rights over ${children[i].new.name_full()} (${children[i].name_full()}) terminated by a court order?
 fields:
   - no label: children[i].no_parental_rights
     datatype: yesnoradio
@@ -794,9 +794,9 @@ fields:
 generic object: ALIndividual
 id: other parental rights terminated
 question: |
-  Were ${x.name.full(middle='full')}'s parental rights terminated by a court order?
+  Were ${x.name_full()}'s parental rights terminated by a court order?
 subquestion: |
-  Only a court can terminate someone's parental rights. If a court has not done so, you should click **No** even if ${x.name.full(middle='full')} does not do any childcare.
+  Only a court can terminate someone's parental rights. If a court has not done so, you should click **No** even if ${x.name_full()} does not do any childcare.
 fields:
   - no label: x.rights_terminated
     datatype: yesnoradio
@@ -804,26 +804,26 @@ fields:
 #I had to make a duplicate of this question for the main_other_parent object because this question pulls up a specific child name.
 id: parents list parent agree
 question: |
-  Does ${children[i].parents[j].name.full(middle='full')} agree to ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s name change?
+  Does ${children[i].parents[j].name_full()} agree to ${children[i].new.name_full()} (${children[i].name_full()})'s name change?
 subquestion: |
-  If ${children[i].parents[j].name.full(middle='full')} agrees to the name change, they will need to sign the name change request before a notary.
+  If ${children[i].parents[j].name_full()} agrees to the name change, they will need to sign the name change request before a notary.
   
-  If ${children[i].parents[j].name.full(middle='full')} cannot sign the name change request, you should select **No** here.
+  If ${children[i].parents[j].name_full()} cannot sign the name change request, you should select **No** here.
   
-  If you are not certain whether ${children[i].parents[j].name.full(middle='full')} would agree to the name change, you may want to ask them before making the name change request forms.
+  If you are not certain whether ${children[i].parents[j].name_full()} would agree to the name change, you may want to ask them before making the name change request forms.
 fields:
   - no label: children[i].parents[j].agree
     datatype: yesnomaybe
 ---    
 id: main other parent agree
 question: |
-  Does ${children[i].main_other_parent.name.full(middle='full')} agree to ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s name change?
+  Does ${children[i].main_other_parent.name_full()} agree to ${children[i].new.name_full()} (${children[i].name_full()})'s name change?
 subquestion: |
-  If ${children[i].main_other_parent.name.full(middle='full')} agrees to the name change, they will need to sign the name change request before a notary.
+  If ${children[i].main_other_parent.name_full()} agrees to the name change, they will need to sign the name change request before a notary.
   
-  If ${children[i].main_other_parent.name.full(middle='full')} cannot sign the name change request, you should select **No** here.
+  If ${children[i].main_other_parent.name_full()} cannot sign the name change request, you should select **No** here.
   
-  If you are not certain whether ${children[i].main_other_parent.name.full(middle='full')} would agree to the name change, you may want to ask them before making the name change request forms.
+  If you are not certain whether ${children[i].main_other_parent.name_full()} would agree to the name change, you may want to ask them before making the name change request forms.
 fields:
   - no label: children[i].main_other_parent.agree
     datatype: yesnomaybe
@@ -852,7 +852,7 @@ subquestion: |
 generic object: ALIndividual
 id: other parent address known
 question: |
-  Do you know ${x.name.full(middle='full')}'s address?
+  Do you know ${x.name_full()}'s address?
 fields:
   - no label: x.address_known
     datatype: yesnoradio
@@ -860,7 +860,7 @@ fields:
 generic object: ALIndividual
 id: other parent address
 question: |
-  What is ${x.name.full(middle='full')}'s address?
+  What is ${x.name_full()}'s address?
 fields:
   - Street address: x.address.address
     address autocomplete: True
@@ -884,7 +884,7 @@ subquestion: |
 #I had to make a duplicate of this question for the other_main_parent object since this question pulls the specific child's name.
 id: other parent risk check
 question: |
-   Are you worried that giving notice of the name change request to ${children[i].parents[j].name.full(middle='full')} would put ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) at risk of physical harm or discrimination?
+   Are you worried that giving notice of the name change request to ${children[i].parents[j].name_full()} would put ${children[i].new.name_full()} (${children[i].name_full()}) at risk of physical harm or discrimination?
 subquestion: |
   ${collapse_template(notice_explainer)}
 fields:
@@ -893,7 +893,7 @@ fields:
 ---
 id: other parent risk check
 question: |
-   Are you worried that giving notice of the name change request to ${children[i].main_other_parent.name.full(middle='full')} would put ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) at risk of physical harm or discrimination?
+   Are you worried that giving notice of the name change request to ${children[i].main_other_parent.name_full()} would put ${children[i].new.name_full()} (${children[i].name_full()}) at risk of physical harm or discrimination?
 subquestion: |
   ${collapse_template(notice_explainer)}
 fields:
@@ -939,14 +939,14 @@ subquestion: |
   
   Parent list generator number gathered: ${parent_list_generator.number_gathered()}
   
-  ${children[i].name.full(middle='full')}
+  ${children[i].name_full()}
   
   name list: comma_and_list(parent_list_generator)}
   
   Do these names not match? 
   
-  * Parent list generator name: parent_list_generator[notice_list_index_tracker].name.full(middle='full')
-  * Main other parent name: child.main_other_parent.name.full(middle='full')
+  * Parent list generator name: parent_list_generator[notice_list_index_tracker].name_full()
+  * Main other parent name: child.main_other_parent.name_full()
 ---
 id: more debug
 continue button field: more_debug
@@ -961,7 +961,7 @@ subquestion: |
  Empty list
  % endif
  
- First in index? ${parent_list_generator[0].name.full(middle='full')}
+ First in index? ${parent_list_generator[0].name_full()}
 ---
 id: third debug
 continue button field: third_debug
@@ -1063,7 +1063,7 @@ code: |
                 already_included = False
                 if parent_list_generator.number_gathered() > 0:                  
                   for item in parent_list_generator:
-                    if child.main_other_parent.name.full(middle='full') == item.name.full(middle='full'):
+                    if child.main_other_parent.name_full() == item.name_full():
                       if child.main_other_parent.address.on_one_line(bare=True) == item.address.on_one_line(bare=True):
                           already_included = True                      
                 if already_included == False:
@@ -1099,7 +1099,7 @@ code: |
                     already_included = False
                     if parent_list_generator.number_gathered() > 0:                  
                       for item in parent_list_generator:
-                        if parent.name.full(middle='full') == item.name.full(middle='full'):
+                        if parent.name_full() == item.name_full():
                           if parent.address.on_one_line(bare=True) == item.address.on_one_line(bare=True):
                               already_included = True                      
                     if already_included == False:
@@ -1171,7 +1171,7 @@ code: |
             
             if child.no_main_parent == False:  
               if defined('parent_list_generator[notice_list_index_tracker].name.first'):
-                if parent_list_generator[notice_list_index_tracker].name.full(middle='full') == child.main_other_parent.name.full(middle='full'):
+                if parent_list_generator[notice_list_index_tracker].name_full() == child.main_other_parent.name_full():
                   parent_list_generator.pop(notice_list_index_tracker)
                   #third_debug
                   popped_main_parent = True
@@ -1181,7 +1181,7 @@ code: |
                 #child.new_debug_screen
                 for childs_parent in child.parents:
                   if defined('parent_list_generator[notice_list_index_tracker].name.first'):
-                    if parent_list_generator[notice_list_index_tracker].name.full(middle='full') == childs_parent.name.full(middle='full'):
+                    if parent_list_generator[notice_list_index_tracker].name_full() == childs_parent.name_full():
                       #childs_parent.guardian_debug
                       parent_list_generator.pop(notice_list_index_tracker)
                       any_popped_in_parents_list = True
@@ -1235,7 +1235,7 @@ code: |
 ---
 id: want to publish check
 question: |
-  Are you concerned publishing notice of ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s name change would put them at risk of harm or discrimination?
+  Are you concerned publishing notice of ${children[i].new.name_full()} (${children[i].name_full()})'s name change would put them at risk of harm or discrimination?
 subquestion: |
   Since you do not know the address of all parents, guardians, or custodians you would need to notify of this name change, you may have to publish notice in a local newspaper. However, you can file a motion requesting you not be required to publish notice.
   
@@ -1258,17 +1258,17 @@ continue button field: children[i].note_about_waiver
 question: |
   About waiving notice
 subquestion: |
-  Based on your answers, you are concerned that notifying the parents, guardians, or custodians of ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s name change request could put the child at risk.
+  Based on your answers, you are concerned that notifying the parents, guardians, or custodians of ${children[i].new.name_full()} (${children[i].name_full()})'s name change request could put the child at risk.
   
-  This program can make a *Motion to Waive Notice and Publication* for ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s name change. The judge may decide not to grant the motion. Judges often require all of a child's parents to be notified of a name change.
+  This program can make a *Motion to Waive Notice and Publication* for ${children[i].new.name_full()} (${children[i].name_full()})'s name change. The judge may decide not to grant the motion. Judges often require all of a child's parents to be notified of a name change.
   
   If you do not want to give notice, you may want a lawyer to help you. Use [**Get Legal Help**](https://www.illinoislegalaid.org/get-legal-help) to find free or low-cost legal services in your area.
 ---
 id: waiver reasons
 question: |
-  Why do you need a notice waiver for ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})?
+  Why do you need a notice waiver for ${children[i].new.name_full()} (${children[i].name_full()})?
 subquestion: |
-  You may need a waiver if you have or did have protection from a court order. You may also need a waiver if publication would be a hardship for ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}).
+  You may need a waiver if you have or did have protection from a court order. You may also need a waiver if publication would be a hardship for ${children[i].new.name_full()} (${children[i].name_full()}).
   
   A protective court order can include:
   
@@ -1328,9 +1328,9 @@ fields:
 # add question if protective order is against one of the other parents
 id: order against parents
 question: |
-  Is the protective order against one of ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s parents?
+  Is the protective order against one of ${children[i].new.name_full()} (${children[i].name_full()})'s parents?
 subquestion: |
-  Click **Yes** if the abuser in the protective order is the parent, guardian, or custodian of ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}).
+  Click **Yes** if the abuser in the protective order is the parent, guardian, or custodian of ${children[i].new.name_full()} (${children[i].name_full()}).
 fields:
   - no label: children[i].order_against_parents
     datatype: yesnoradio
@@ -1420,9 +1420,9 @@ fields:
 id: hardship reason
 question: |
   % if children[i].child_notice_would_be_published == True:
-  Explain why publication and giving notice would be a hardship for ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})
+  Explain why publication and giving notice would be a hardship for ${children[i].new.name_full()} (${children[i].name_full()})
   % else:
-  Explain why giving notice would be a hardship for ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})
+  Explain why giving notice would be a hardship for ${children[i].new.name_full()} (${children[i].name_full()})
   % endif
 subquestion: |
   ${collapse_template(notice_waiver_example)}
@@ -1436,7 +1436,7 @@ template: notice_waiver_example
 subject: |
   **What should my answer look like?**
 content: |  
-  This explanation will go on your *Motion to Waive Notice and Publication*. You should explain why giving or publishing notice would put ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) at risk of physical harm or discrimination.
+  This explanation will go on your *Motion to Waive Notice and Publication*. You should explain why giving or publishing notice would put ${children[i].new.name_full()} (${children[i].name_full()}) at risk of physical harm or discrimination.
 
   Here are some examples: 
   
@@ -1447,7 +1447,7 @@ content: |
 generic object: ALIndividual
 id: other parent notice method
 question: |
-  How will you give ${x.name.full(middle='full')} notice of this name change request?
+  How will you give ${x.name_full()} notice of this name change request?
 subquestion: |
   You can give notice by certified mail or by asking the sheriff to deliver a copy of the forms to the other parents or custodian. You can only notify them by newspaper if you do not know their address.
 field: x.receive_method 
@@ -1470,7 +1470,7 @@ subquestion: |
 ---
 id: child safety address
 question: |
-  Do you want to use the safe mailing address for ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})?
+  Do you want to use the safe mailing address for ${children[i].new.name_full()} (${children[i].name_full()})?
 subquestion: |
   You need to put an address on the court forms where you can receive information about the case. It does not have to be the address where the child lives.
   
@@ -1658,7 +1658,7 @@ id: signature
 question: |
   Do you want to add your e-signature to your forms?
 subquestion: |
-  This program can put "**/s/ ${users[0].name.full(middle='full')}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${users[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
   
   If you do not add your **{e-signature}** now, you must sign your forms before you file them.
   % if defined("notarized_signature"):
@@ -1920,7 +1920,7 @@ attachment:
   pdf template file: Request_for_Name_Change_Minor.pdf
   fields:
     - "filing_county": ${filing_county}
-    - "user_name": ${ users[0].name.full(middle='full')}
+    - "user_name": ${ users[0].name_full()}
     - "case_number": ${""}
     - "one_child_old_first": ${children[0].name.first}
     - "one_child_old_middle": ${children[0].name.middle}
@@ -1949,7 +1949,7 @@ attachment:
     - "more_than_four_kids": ${True if children.number_gathered() > 4 else False}
     - "child_info_attached": ${True}
     #- "illinois_start_date": ${format_date(started_living_in_illinois, format='long')}
-    - "e_signature": ${ users[0].name.full(middle='full') if e_signature == True else ""}
+    - "e_signature": ${ users[0].name_full() if e_signature == True else ""}
     - "six_months": ${False if any_under_six_months else True}
     - "user_address": ${users[0].address.on_one_line(bare=True)}
     - "user_phone": ${phone_number_formatted(users[0].phone_number)}
@@ -1967,7 +1967,7 @@ attachment:
   fields:
     - "case_number": ${""}
     - "filing_county": ${filing_county}
-    - "user_name": ${ users[0].name.full(middle='full')}
+    - "user_name": ${ users[0].name_full()}
     - "child_old_first_5": ${children[4].name.first}
     - "child_old_middle_5": ${children[4].name.middle}
     - "child_old_last_5": ${children[4].name.last if children[4].name.suffix == "" else (children[4].name.last + " " + children[4].name.suffix)}
@@ -2021,7 +2021,7 @@ attachment:
   pdf template file: order_to_waive_notice.pdf
   fields:
     - "trial_court_county": ${filing_county}
-    - "user": ${ users[0].name.full(middle="full") }
+    - "user": ${ users[0].name_full() }
 ---    
 generic object: ALIndividual
 attachment:
@@ -2033,7 +2033,7 @@ attachment:
   pdf template file: motion_to_waive_notice.pdf
   fields:      
     - "trial_court_county": ${ trial_court.address.county.upper() }
-    - "user__1": ${ users[0].name.full(middle="full") }
+    - "user__1": ${ users[0].name_full() }
     - "waiver_order_cb": ${ True if x.waiver_reason['order'] == True else '' }
     - "protective_order_op": ${ True if x.protective_order['op'] == True else '' }
     - "protective_order_snco": ${ True if x.protective_order['snco'] == True else '' }
@@ -2057,8 +2057,8 @@ attachment:
     - "order_county_4": ${ x.orders[3].name.text if x.waiver_reason['order'] == True else '' }
     - "order_state_4": ${ x.orders[3].state if x.waiver_reason['order'] == True else '' }
     - "order_case_number_4": ${ x.orders[3].number if x.waiver_reason['order'] == True else '' }
-    - "user_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-    - "user__2": ${ users[0].name.full(middle="full") }
+    - "user_signature": ${ users[0].name_full() if e_signature else '' }
+    - "user__2": ${ users[0].name_full() }
     - "user_address": ${ users[0].address.on_one_line(bare=True) }
     - "user_hide_address_cb": ${ True if use_safe_address else '' }
     - "user_phone": ${ phone_number_formatted(users[0].phone_number) }
@@ -2077,7 +2077,7 @@ attachment:
   pdf template file: Notice_of_Court_Date_Minor2.pdf
   fields:  
     - "filing_county": ${filing_county}
-    - "user_name": ${ users[0].name.full(middle='full')}
+    - "user_name": ${ users[0].name_full()}
     - "case_number": ${""}
     - "court_date": ${""}
     - "court_time": ${""}
@@ -2092,22 +2092,22 @@ attachment:
     - "call_in_number": ${""}
     - "clerk_phone": ${""}
     - "clerk_website": ${""}
-    - "other_parent_name": ${x.name.full(middle='full')}
+    - "other_parent_name": ${x.name_full()}
     - "other_parent_address": ${x.address.on_one_line(bare=True) if x.address_known == True else ""}
     - "by_mail_1": ${True if x.receive_method == "mail" else False}
     - "by_sheriff_1": ${True if x.receive_method == "sheriff" else False}
     - "other_parent_notice_date": ${""}
-    - "guardian_name": ${x.second_person.name.full(middle='full')}
+    - "guardian_name": ${x.second_person.name_full()}
     - "guardian_address": ${x.second_person.address.on_one_line(bare=True) if x.second_person.address_known == True else ""}
     - "by_mail_2": ${True if x.second_person.receive_method == "mail" else False}
     - "by_sheriff_2": ${True if x.second_person.receive_method == "sheriff" else False}
     - "guardian_notice_date": ${""}
-    - "custodian_name": ${x.third_person.name.full(middle='full')}
+    - "custodian_name": ${x.third_person.name_full()}
     - "custodian_address": ${x.third_person.address.on_one_line(bare=True) if x.third_person.address_known == True else ""}
     - "by_mail_3": ${True if x.third_person.receive_method == "mail" else False}
     - "by_sheriff_3": ${True if x.third_person.receive_method == "sheriff" else False}
     - "custodian_notice_date": ${""}
-    - "e_signature": ${ users[0].name.full(middle='full') if e_signature == True else ""}
+    - "e_signature": ${ users[0].name_full() if e_signature == True else ""}
     - "user_address": ${users[0].address.on_one_line(bare=True)}
     - "alternate_address": ${use_safe_address}
     - "user_phone": ${phone_number_formatted(users[0].phone_number)}
@@ -2122,7 +2122,7 @@ attachment:
   pdf template file: Order_for_Name_Change_Minor.pdf
   fields:  
     - "filing_county": ${filing_county}
-    - "user_name": ${ users[0].name.full(middle='full')}
+    - "user_name": ${ users[0].name_full()}
     - "case_number": ${""}
 ---
 attachment:
@@ -2134,16 +2134,16 @@ attachment:
   pdf template file: Publication_Notice_Minor2.pdf
   fields: 
     - "filing_county": ${filing_county}
-    - "user_name": ${ users[0].name.full(middle='full')}
+    - "user_name": ${ users[0].name_full()}
     - "case_number": ${""}
-    - "child_old_name_1": ${published_children[0].name.full(middle='full')}
-    - "child_new_name_1": ${published_children[0].new.name.full(middle='full')}
-    - "child_old_name_2": ${published_children[1].name.full(middle='full')}
-    - "child_new_name_2": ${published_children[1].new.name.full(middle='full')}
-    - "child_old_name_3": ${published_children[2].name.full(middle='full')}
-    - "child_new_name_3": ${published_children[2].new.name.full(middle='full')}
-    - "child_old_name_4": ${published_children[3].name.full(middle='full')}
-    - "child_new_name_4": ${published_children[3].new.name.full(middle='full')}
+    - "child_old_name_1": ${published_children[0].name_full()}
+    - "child_new_name_1": ${published_children[0].new.name_full()}
+    - "child_old_name_2": ${published_children[1].name_full()}
+    - "child_new_name_2": ${published_children[1].new.name_full()}
+    - "child_old_name_3": ${published_children[2].name_full()}
+    - "child_new_name_3": ${published_children[2].new.name_full()}
+    - "child_old_name_4": ${published_children[3].name_full()}
+    - "child_new_name_4": ${published_children[3].new.name_full()}
     - "more_than_four_kids": ${True if published_children.number_gathered() > 4 else False}
     - "court_date": ${""}
     - "court_time": ${""}
@@ -2158,7 +2158,7 @@ attachment:
     - "call_in_number": ${""}
     - "clerk_phone": ${""}
     - "clerk_website": ${""}
-    - "e_signature": ${ users[0].name.full(middle='full') if e_signature == True else ""}
+    - "e_signature": ${ users[0].name_full() if e_signature == True else ""}
     - "user_address": ${users[0].address.on_one_line(bare=True)}
     - "alternate_address": ${use_safe_address}
     - "user_phone": ${phone_number_formatted(users[0].phone_number)}
@@ -2217,7 +2217,7 @@ attachment:
   pdf template file: Request_for_Name_Change_Child_Information.pdf
   fields: 
     - "filing_county": ${filing_county}
-    - "user_name": ${ users[0].name.full(middle='full')}
+    - "user_name": ${ users[0].name_full()}
     - "case_number": ${""}
     - "child_old_first": ${children[i].name.first}
     - "child_old_middle": ${children[i].name.middle}
@@ -2327,13 +2327,13 @@ attachment:
     - "other_parent_name_full": |
         % if children[i].include_main_parent_on_child_sheet == True:
         % if children[i].main_other_parent.agree == True:
-        ${children[i].main_other_parent.name.full(middle='full')}
+        ${children[i].main_other_parent.name_full()}
         % else:
         ${""}
         % endif
         % elif children[i].include_parents_zero_on_child_sheet == True:
         % if children[i].parents[0].agree == True:
-        ${children[i].parents[0].name.full(middle='full')}
+        ${children[i].parents[0].name_full()}
         % else:
         ${""}
         % endif
@@ -2395,7 +2395,7 @@ attachment:
   pdf template file: name_change_additional_criminal_history.pdf
   fields:
     - "trial_court_county": ${ filing_county }
-    - "user__1": ${ children[i].name.full(middle='full') }
+    - "user__1": ${ children[i].name_full() }
     - "user_offense_name_4": ${ children[i].convictions[3].name.text }
     - "user_conviction_date_4": ${ format_date(children[i].convictions[3].date, format='MM/dd/yyyy') }
     - "user_sentence_4": ${ children[i].convictions[3].sentence }
@@ -2514,14 +2514,14 @@ attachment:
   pdf template file: Request_for_Name_Change_Additonal_Parent_Minor.pdf
   fields: 
     - "case_number": ${""}
-    - "user_name": ${ users[0].name.full(middle='full')}
+    - "user_name": ${ users[0].name_full()}
     - "filing_county": ${filing_county}
     - "is_parent_or_guardian": ${True if children[i].parents[j].parent_type != "Custodian" else False}
     - "is_custodian": ${True if children[i].parents[j].parent_type == "Custodian" else False}
     - "parental_first": ${children[i].parents[j].name.first}
     - "parental_middle": ${children[i].parents[j].name.middle}
     - "parental_last": ${children[i].parents[j].name.last if children[i].parents[j].name.suffix == "" else (children[i].parents[j].name.last + " " + children[i].parents[j].name.suffix)}
-    - "other_parent_name_full": ${children[i].parents[j].name.full(middle='full') if children[i].parents[j].agree else ""}
+    - "other_parent_name_full": ${children[i].parents[j].name_full() if children[i].parents[j].agree else ""}
     - "parental_address": ${children[i].parents[j].address.on_one_line(bare=True) if children[i].parents[j].address_known else "Unknown"}
     - "certified_or_sheriff": ${True if children[i].parents[j].address_known == True and children[i].parents[j].agree != True else False}
     - "publication_notice": ${children[i].parents[j].publication_needer}
@@ -2568,13 +2568,13 @@ question: |
     Does your spouse have any arrests for which charges have not been filed?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) have any arrests for which charges have not been filed?
+  Does ${x[i].new.name_full()} (${x[i].name_full()}) have any arrests for which charges have not been filed?
   % endif
 subquestion: |
   % if interview_type == 'adult':
   If you were arrested but did not go to court or see a judge, then you were probably not charged with a crime. That means charges are pending.
   % else:
-  If ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) was arrested but did not go to court or see a judge, then they were probably not charged with a crime. That means charges are pending.
+  If ${x[i].new.name_full()} (${x[i].name_full()}) was arrested but did not go to court or see a judge, then they were probably not charged with a crime. That means charges are pending.
   % endif
 fields:
   - no label: x[i].pending_arrests
@@ -2590,7 +2590,7 @@ question: |
     Does your spouse have any pending misdemeanor or felony charges?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) have any pending misdemeanor or felony charges?
+  Does ${x[i].new.name_full()} (${x[i].name_full()}) have any pending misdemeanor or felony charges?
   % endif
 subquestion: |
   % if interview_type == 'adult':
@@ -2600,7 +2600,7 @@ subquestion: |
     In other words, does your spouse have any ongoing criminal cases against them for misdemeanor or felony offenses?
     % endif
   % else:
-    In other words, does ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) have any ongoing criminal cases against them for misdemeanor or felony offenses?
+    In other words, does ${x[i].new.name_full()} (${x[i].name_full()}) have any ongoing criminal cases against them for misdemeanor or felony offenses?
   % endif
 fields:
   - no label: x[i].pending_charges
@@ -2616,7 +2616,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for any misdemeanors?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) have any misdemeanor convictions or were they placed on probation for any misdemeanors?
+  Does ${x[i].new.name_full()} (${x[i].name_full()}) have any misdemeanor convictions or were they placed on probation for any misdemeanors?
   % endif
 subquestion: |
   These can be misdemeanors in Illinois or any other state.
@@ -2639,7 +2639,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for any felonies?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) have any felony convictions or were they placed on probation for any felonies?
+  Does ${x[i].new.name_full()} (${x[i].name_full()}) have any felony convictions or were they placed on probation for any felonies?
   % endif
 subquestion: |
   These can be felonies in Illinois or any other state.
@@ -2662,7 +2662,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for a crime that required them to register?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) have any convictions or were they placed on probation for a crime that required them register?
+  Does ${x[i].new.name_full()} (${x[i].name_full()}) have any convictions or were they placed on probation for a crime that required them register?
   % endif
 subquestion: |
   These include crimes that require registration under the:
@@ -2734,7 +2734,7 @@ question: |
     Does your spouse have any convictions or were they placed on probation for identity theft?
     % endif
   % else:
-  Does ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) have any convictions or were they placed on probation for identity theft?
+  Does ${x[i].new.name_full()} (${x[i].name_full()}) have any convictions or were they placed on probation for identity theft?
   % endif
 subquestion: |
   This includes **identity theft** or **aggravated identity theft**.
@@ -2748,7 +2748,7 @@ subquestion: |
     Your spouse can still request a name change even if you answer **Yes**.
     % endif
   % else:
-  You can still request a name change for ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}) even if you answer **Yes**.
+  You can still request a name change for ${x[i].new.name_full()} (${x[i].name_full()}) even if you answer **Yes**.
   % endif
 fields:
   - no label: x[i].id_theft
@@ -2767,7 +2767,7 @@ subquestion: |
     For these convictions or probations, you must enter more information on your spouse's name change request:
     % endif
   % else:
-  For these convictions or probations of ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}), you must enter more information:
+  For these convictions or probations of ${x[i].new.name_full()} (${x[i].name_full()}), you must enter more information:
   % endif
 
   % if x[i].felonies:
@@ -2797,7 +2797,7 @@ subquestion: |
     For any of the following convictions or probations, you must enter more information on your spouse's name change request:
     % endif
   % else:
-  For any of the following convictions or probations of ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}), you must enter more information:
+  For any of the following convictions or probations of ${x[i].new.name_full()} (${x[i].name_full()}), you must enter more information:
   % endif
   
   % if x[i].felonies:
@@ -2856,7 +2856,7 @@ subquestion: |
     For any of the following convictions or probations, you must enter more information on your spouse's name change request:
     % endif
   % else:
-  For these convictions or probations of ${x[i].new.name.full(middle='full')} (${x[i].name.full(middle='full')}), you must enter more information on your name change request:
+  For these convictions or probations of ${x[i].new.name_full()} (${x[i].name_full()}), you must enter more information on your name change request:
   % endif
 
   % if x[i].felonies:
@@ -2889,7 +2889,7 @@ subquestion: |
   So far you have told us about: 
   
   % for child in children:
-  * ${child.new.name.full(middle='full')} (${child.name.full(middle='full')})
+  * ${child.new.name_full()} (${child.name_full()})
   % endfor
 fields:
   - no label: children.there_is_another
@@ -2897,7 +2897,7 @@ fields:
 ---
 id: parents there is another
 question: |
-  Does ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')}) have another parent, guardian, or custodian?
+  Does ${children[i].new.name_full()} (${children[i].name_full()}) have another parent, guardian, or custodian?
 subquestion: |
   % if children[i].no_main_parent == False:
   So far you have told us about ${comma_and_list(children[i].main_other_parent, children[i].parents)}.
@@ -2944,7 +2944,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle='full')}
+      ${users[0].name_full()}
   - Edit: use_safe_address 
     button: |
       **Do you want to use an alternate mailing address?**
@@ -2974,7 +2974,7 @@ review:
       **Children: (Edit to change names, addresses, and other information)**
 
       % for my_var in children:
-        * ${ my_var.new.name.full(middle="full")} (${my_var.name.full(middle='full')})
+        * ${ my_var.new.name_full()} (${my_var.name_full()})
       % endfor
   - label: Edit
     fields:
@@ -3023,7 +3023,7 @@ review:
       **Children: (Edit to change if and how you will give parents and guardians notice )**
 
       % for my_var in children:
-        * ${ my_var.new.name.full(middle="full")} (${my_var.name.full(middle='full')})
+        * ${ my_var.new.name_full()} (${my_var.name_full()})
       % endfor
 ---
 section: Children and parents
@@ -3041,14 +3041,14 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle='full')}
+      ${users[0].name_full()}
     show if: users[0].name.first == "This is just included so the Children review screen can have the table and the resume button"
   #- Edit: children.revisit
   #  button: |
   #    **Children: (Edit to change names, addresses, and other information)**
 #
   #    % for my_var in children:
-  #      * ${ my_var.new.name.full(middle="full")} (${my_var.name.full(middle='full')})
+  #      * ${ my_var.new.name_full()} (${my_var.name_full()})
   #    % endfor
 ---
 id: children review screen
@@ -3063,7 +3063,7 @@ subquestion: |
 id: parents review
 continue button field: children[i].parents.revisit
 question: |
-  Edit the information about ${children[i].new.name.full(middle='full')} (${children[i].name.full(middle='full')})'s parents, guardians, and custodians
+  Edit the information about ${children[i].new.name_full()} (${children[i].name_full()})'s parents, guardians, and custodians
 subquestion: |
   ${ children[i].parents.table }
   
@@ -3074,7 +3074,7 @@ table: children.table
 rows: children
 columns:
   - Current name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
   - New name, address, and other information: |
       action_button_html(url_action(row_item.attr_name("review_child")), label="Edit", icon="pencil-alt")
 delete buttons: True
@@ -3086,7 +3086,7 @@ table: children[i].parents.table
 rows: children[i].parents
 columns:
   - Name: |
-      row_item.name.full(middle='full') if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
   - Address and other information: |
       action_button_html(url_action(row_item.attr_name("review_parent")), label="Edit", icon="pencil-alt")
 delete buttons: True
@@ -3096,29 +3096,29 @@ id: child review screen
 continue button field: x.review_child
 generic object: ALIndividual
 question: |
-  Edit ${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s information
+  Edit ${x.new.name_full()} (${x.name_full()})'s information
 review: 
   - note: |
-      #### ${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s identity
+      #### ${x.new.name_full()} (${x.name_full()})'s identity
   - Edit: x.name.first
     button: |
       **Current name:**
-      ${x.name.full(middle='full')}
+      ${x.name_full()}
   - Edit: x.new.name.first
     button: |
       **New name:**
-      ${x.new.name.full(middle='full')}
+      ${x.new.name_full()}
   - Edit: x.birthdate
     button: |
       **Birth date:**
       ${x.birthdate}
   - Edit: x.six_months_in_illinois
     button: |
-      **Has ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) lived in Illinois for at least 6 months?**
+      **Has ${x.new.name_full()} (${x.name_full()}) lived in Illinois for at least 6 months?**
       ${word(yesno(x.six_months_in_illinois))}
   - Edit: x.user_relationship
     button: |
-      **Your relationship to ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}):**
+      **Your relationship to ${x.new.name_full()} (${x.name_full()}):**
       % if x.user_relationship == "bio":
       Biological parent
       % elif x.user_relationship == "adopt":
@@ -3132,12 +3132,12 @@ review:
       % endif
   - Edit: x.no_parental_rights
     button: |
-      **Were your parental rights over ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) terminated?**
+      **Were your parental rights over ${x.new.name_full()} (${x.name_full()}) terminated?**
       ${word(yesno(x.no_parental_rights))}
     show if: x.user_relationship == "bio" or x.user_relationship == "adopt"
   - Edit: x.change_reasons
     button: |
-      **Why are you changing this child's name from "${x.name.full(middle='full')}" to "${x.new.name.full(middle='full')}?"**
+      **Why are you changing this child's name from "${x.name_full()}" to "${x.new.name_full()}?"**
       
       % if x.change_reasons['user_wants']:
       * I want to change their name.
@@ -3150,7 +3150,7 @@ review:
       % endif
   - Edit: x.birth_place.in_america
     button: |
-      **${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s birth place:**
+      **${x.new.name_full()} (${x.name_full()})'s birth place:**
       % if x.birth_place.in_america == True:
       ${x.birth_place.city}, ${end_in_county(x.birth_place.county)}, ${x.birth_place.state}
       % else:
@@ -3158,27 +3158,27 @@ review:
       % endif
   - Edit: x.use_safe_address
     button: |
-      **Do you want to use ${users[0].address.on_one_line(bare=True)} as ${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s address?**
+      **Do you want to use ${users[0].address.on_one_line(bare=True)} as ${x.new.name_full()} (${x.name_full()})'s address?**
       ${word(yesno(x.use_safe_address))}
     show if: use_safe_address 
   - Edit: x.address.address
     button: |
-      **${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s address:**
+      **${x.new.name_full()} (${x.name_full()})'s address:**
       ${x.address.on_one_line(bare=True)}
     #show if: showifdef('x.use_safe_address') != True
   - note: |
-      #### ${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s criminal history
+      #### ${x.new.name_full()} (${x.name_full()})'s criminal history
   - Edit: x.pending_arrests
     button: |
-      **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have any arrests for which charges have not been filed?**
+      **Does ${x.new.name_full()} (${x.name_full()}) have any arrests for which charges have not been filed?**
       ${word(yesno(x.pending_arrests))}
   - Edit: x.pending_charges
     button: |
-      **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have any pending misdemeanor or felony charges?**
+      **Does ${x.new.name_full()} (${x.name_full()}) have any pending misdemeanor or felony charges?**
       ${word(yesno(x.pending_charges))}
   - Edit: x.misdemeanors
     button: |
-      **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have any misdemeanor convictions or were they placed on probation for any misdemeanors?**
+      **Does ${x.new.name_full()} (${x.name_full()}) have any misdemeanor convictions or were they placed on probation for any misdemeanors?**
       % if x.misdemeanors == False:
       No
       % else:
@@ -3190,7 +3190,7 @@ review:
       % endif
   - Edit: x.felonies
     button: |
-      **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have any felony convictions or were they placed on probation for any felonies?**
+      **Does ${x.new.name_full()} (${x.name_full()}) have any felony convictions or were they placed on probation for any felonies?**
       % if x.felonies == False:
       No
       % else:
@@ -3202,7 +3202,7 @@ review:
       % endif
   - Edit: x.registry
     button: |
-      **Do ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have any convictions or were they placed on probation for a crime that required them register?**
+      **Do ${x.new.name_full()} (${x.name_full()}) have any convictions or were they placed on probation for a crime that required them register?**
       % if x.registry == False:
       No
       % elif x.registry_exceptions.all_false():
@@ -3225,20 +3225,20 @@ review:
       % endif
   - Edit: x.id_theft
     button: |
-      **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have any convictions or were they placed on probation for identity theft?**
+      **Does ${x.new.name_full()} (${x.name_full()}) have any convictions or were they placed on probation for identity theft?**
       ${word(yesno(x.id_theft))}
   - Edit: x.convictions.revisit
     button: |
-      **${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s convictions: (Edit to change details)**
+      **${x.new.name_full()} (${x.name_full()})'s convictions: (Edit to change details)**
 
       % for my_var in x.convictions:
         * ${ my_var.name.text } on ${ my_var.date }
       % endfor
   - note: |
-      #### ${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s other parent
+      #### ${x.new.name_full()} (${x.name_full()})'s other parent
   #- Edit: x.no_main_parent
   #  button: |
-  #    **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have a parent other than you?**
+  #    **Does ${x.new.name_full()} (${x.name_full()}) have a parent other than you?**
   #    % if x.no_main_parent == False:
   #    Yes
   #    % else:
@@ -3246,7 +3246,7 @@ review:
   #    % endif
   - Edit: x.other_parent_status
     button: |
-      **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have a parent other than you?**
+      **Does ${x.new.name_full()} (${x.name_full()}) have a parent other than you?**
       % if x.other_parent_status == "has_other_parent":
       Yes
       % elif x.other_parent_status == "deceased_parent":
@@ -3257,16 +3257,16 @@ review:
   - Edit: x.main_other_parent.name.first
     button: |
       **Other parent's name:**
-      ${x.main_other_parent.name.full(middle='full')}
+      ${x.main_other_parent.name_full()}
     show if: x.no_main_parent == False
   - Edit: x.main_other_parent.rights_terminated
     button: |
-      **Were ${x.main_other_parent.name.full(middle='full')}'s parental rights terminated?**
+      **Were ${x.main_other_parent.name_full()}'s parental rights terminated?**
       ${word(yesno(x.main_other_parent.rights_terminated))}
     show if: x.no_main_parent == False
   - Edit: x.main_other_parent.agree
     button: |
-      **Does ${x.main_other_parent.name.full(middle='full')} agree to the name change?**
+      **Does ${x.main_other_parent.name_full()} agree to the name change?**
       % if x.main_other_parent.agree != True and x.main_other_parent.agree != False:
       I don't know
       % else:
@@ -3275,22 +3275,22 @@ review:
     show if: x.no_main_parent == False and x.main_other_parent.rights_terminated == False
   - Edit: x.main_other_parent.address_known
     button: |
-      **Do you know ${x.main_other_parent.name.full(middle='full')}'s address?**
+      **Do you know ${x.main_other_parent.name_full()}'s address?**
       ${word(yesno(x.main_other_parent.address_known))}
     show if: x.no_main_parent == False
   - Edit: x.main_other_parent.address.address
     button: |
-      **${x.main_other_parent.name.full(middle='full')}'s address:**
+      **${x.main_other_parent.name_full()}'s address:**
       ${x.main_other_parent.address.on_one_line(bare=True)}
     show if: x.no_main_parent == False and x.main_other_parent.address_known == True
   - Edit: x.main_other_parent.risk_check 
     button: |
-      **Are you worried that giving notice to ${x.main_other_parent.name.full(middle='full')} of the name change request would put your child at risk?**
+      **Are you worried that giving notice to ${x.main_other_parent.name_full()} of the name change request would put your child at risk?**
       ${word(yesno(x.main_other_parent.risk_check))}
     show if: x.no_main_parent == False and x.main_other_parent.agree != True
   - Edit: x.main_other_parent.receive_method
     button: |
-      **How will you give ${x.main_other_parent.name.full(middle='full')} notice of this name change request?**
+      **How will you give ${x.main_other_parent.name_full()} notice of this name change request?**
       % if x.receive_method == "mail":
       I will give notice of this Request and the scheduled court date by certified mail.
       % elif x.receive_method == "sheriff":
@@ -3304,9 +3304,9 @@ review:
   - Edit: x.any_other_parents
     button: |
       % if x.no_main_parent == False:
-      **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have any other parents, guardians, or custodians?**
+      **Does ${x.new.name_full()} (${x.name_full()}) have any other parents, guardians, or custodians?**
       % else:
-      **Does ${x.new.name.full(middle='full')} (${x.name.full(middle='full')}) have any guardians or custodians other than you?**
+      **Does ${x.new.name_full()} (${x.name_full()}) have any guardians or custodians other than you?**
       % endif
       ${word(yesno(x.any_other_parents))}
   - Edit: x.parents.revisit
@@ -3318,14 +3318,14 @@ review:
       % endif
       
       % for my_var in x.parents:
-        * ${ my_var.name.full(middle="full")}
+        * ${ my_var.name_full()}
       % endfor
     show if: x.any_other_parents
   - note: |
       #### Notice and waiver (if applicable)
   - Edit: x.request_waiver
     button: |
-      **Are you concerned publishing notice of ${x.new.name.full(middle='full')} (${x.name.full(middle='full')})'s name change would put them at risk?**
+      **Are you concerned publishing notice of ${x.new.name_full()} (${x.name_full()})'s name change would put them at risk?**
       ${word(yesno(x.request_waiver))}
     #show if: x.child_notice_would_be_published == True
   - Edit:  x.waiver_reason
@@ -3454,26 +3454,26 @@ id: parent review
 continue button field: x.review_parent
 generic object: ALIndividual
 question: |
-  Edit ${x.name.full(middle='full')}'s information
+  Edit ${x.name_full()}'s information
 review: 
   - note: |
-      #### About ${x.name.full(middle='full')}
+      #### About ${x.name_full()}
   - Edit: x.name.first
     button: |
       **Name of parent, guardian, or custodian:**
-      ${x.name.full(middle='full')}   
+      ${x.name_full()}   
   - Edit: x.parent_type
     button: |
-      **Is ${x.name.full(middle='full')} a parent, guardian, or custodian?**
+      **Is ${x.name_full()} a parent, guardian, or custodian?**
       ${x.parent_type}
   - Edit: x.rights_terminated
     button: |
-      **Were ${x.name.full(middle='full')}'s parental rights terminated?**
+      **Were ${x.name_full()}'s parental rights terminated?**
       ${word(yesno(x.rights_terminated))}
     show if: x.parent_type == "Parent"
   - Edit: x.agree
     button: |
-      **Does ${x.name.full(middle='full')} agree to the name change?**
+      **Does ${x.name_full()} agree to the name change?**
       % if x.agree != True and x.agree != False:
       I don't know
       % else:
@@ -3483,21 +3483,21 @@ review:
       #### Notice
   - Edit: x.address_known
     button: |
-      **Do you know ${x.name.full(middle='full')}'s address?**
+      **Do you know ${x.name_full()}'s address?**
       ${word(yesno(x.address_known))}
   - Edit: x.address.address
     button: |
-      **${x.name.full(middle='full')}'s address:**
+      **${x.name_full()}'s address:**
       ${x.address.on_one_line(bare=True)}
     show if: x.address_known == True
   - Edit: x.risk_check 
     button: |
-      **Are you worried that giving notice to ${x.name.full(middle='full')} of the name change request would put your child at risk?**
+      **Are you worried that giving notice to ${x.name_full()} of the name change request would put your child at risk?**
       ${word(yesno(x.risk_check))}
     show if: x.agree != True
   - Edit: x.receive_method
     button: |
-      **How will you give ${x.name.full(middle='full')} notice of this name change request?**
+      **How will you give ${x.name_full()} notice of this name change request?**
       % if x.receive_method == "mail":
       I will give notice of this Request and the scheduled court date by certified mail.
       % elif x.receive_method == "sheriff":
@@ -3522,7 +3522,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle='full')}
+      ${users[0].name_full()}
   - Edit: use_safe_address 
     button: |
       **Do you want to use an alternate mailing address?**


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>